### PR TITLE
Adicionar API FastAPI para leituras de sensores Fildee

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,13 @@
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql+psycopg2://postgres:postgres@localhost:5432/fildee",
+)
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,50 @@
+from fastapi import Depends, FastAPI, HTTPException, status
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+from .database import Base, SessionLocal, engine
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Fildee Sensor API")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.post(
+    "/sensor-readings",
+    response_model=schemas.SensorReadingResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_sensor_reading(
+    payload: schemas.SensorReadingCreate,
+    db: Session = Depends(get_db),
+):
+    reading = models.SensorReading(**payload.model_dump())
+    db.add(reading)
+    db.commit()
+    db.refresh(reading)
+    return reading
+
+
+@app.get("/sensor-readings/latest", response_model=schemas.SensorReadingResponse)
+def get_latest_sensor_reading(db: Session = Depends(get_db)):
+    reading = (
+        db.query(models.SensorReading)
+        .order_by(models.SensorReading.read_at.desc(), models.SensorReading.id.desc())
+        .first()
+    )
+
+    if not reading:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Nenhuma leitura encontrada",
+        )
+
+    return reading

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,22 @@
+from sqlalchemy import Column, DateTime, Float, Integer, String
+
+from .database import Base
+
+
+class SensorReading(Base):
+    __tablename__ = "sensor_readings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    farm_id = Column(String(64), nullable=False, index=True)
+    station_id = Column(String(64), nullable=False, index=True)
+    crop = Column(String(100), nullable=False)
+    air_temperature = Column(Float, nullable=False)
+    air_humidity = Column(Float, nullable=False)
+    soil_temperature = Column(Float, nullable=False)
+    soil_humidity = Column(Float, nullable=False)
+    ph = Column(Float, nullable=False)
+    nitrogen = Column(Float, nullable=False)
+    phosphorus = Column(Float, nullable=False)
+    potassium = Column(Float, nullable=False)
+    battery_level = Column(Float, nullable=False)
+    read_at = Column(DateTime(timezone=True), nullable=False, index=True)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class SensorReadingBase(BaseModel):
+    farm_id: str = Field(min_length=1, max_length=64)
+    station_id: str = Field(min_length=1, max_length=64)
+    crop: str = Field(min_length=1, max_length=100)
+    air_temperature: float = Field(ge=-80, le=80)
+    air_humidity: float = Field(ge=0, le=100)
+    soil_temperature: float = Field(ge=-30, le=80)
+    soil_humidity: float = Field(ge=0, le=100)
+    ph: float = Field(ge=0, le=14)
+    nitrogen: float = Field(ge=0)
+    phosphorus: float = Field(ge=0)
+    potassium: float = Field(ge=0)
+    battery_level: float = Field(ge=0, le=100)
+    read_at: datetime
+
+    @field_validator("read_at")
+    @classmethod
+    def validate_read_at_not_far_future(cls, value: datetime) -> datetime:
+        # tolerância de 5 minutos para clock drift
+        if value.timestamp() - datetime.now(value.tzinfo).timestamp() > 300:
+            raise ValueError("read_at não pode estar muito no futuro")
+        return value
+
+
+class SensorReadingCreate(SensorReadingBase):
+    pass
+
+
+class SensorReadingResponse(SensorReadingBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)

--- a/migrations/versions/20260425_0001_create_sensor_readings.py
+++ b/migrations/versions/20260425_0001_create_sensor_readings.py
@@ -1,0 +1,55 @@
+"""create sensor_readings table
+
+Revision ID: 20260425_0001
+Revises:
+Create Date: 2026-04-25 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20260425_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sensor_readings",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("farm_id", sa.String(length=64), nullable=False),
+        sa.Column("station_id", sa.String(length=64), nullable=False),
+        sa.Column("crop", sa.String(length=100), nullable=False),
+        sa.Column("air_temperature", sa.Float(), nullable=False),
+        sa.Column("air_humidity", sa.Float(), nullable=False),
+        sa.Column("soil_temperature", sa.Float(), nullable=False),
+        sa.Column("soil_humidity", sa.Float(), nullable=False),
+        sa.Column("ph", sa.Float(), nullable=False),
+        sa.Column("nitrogen", sa.Float(), nullable=False),
+        sa.Column("phosphorus", sa.Float(), nullable=False),
+        sa.Column("potassium", sa.Float(), nullable=False),
+        sa.Column("battery_level", sa.Float(), nullable=False),
+        sa.Column("read_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_sensor_readings_id"), "sensor_readings", ["id"], unique=False)
+    op.create_index(
+        op.f("ix_sensor_readings_farm_id"), "sensor_readings", ["farm_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_sensor_readings_station_id"), "sensor_readings", ["station_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_sensor_readings_read_at"), "sensor_readings", ["read_at"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_sensor_readings_read_at"), table_name="sensor_readings")
+    op.drop_index(op.f("ix_sensor_readings_station_id"), table_name="sensor_readings")
+    op.drop_index(op.f("ix_sensor_readings_farm_id"), table_name="sensor_readings")
+    op.drop_index(op.f("ix_sensor_readings_id"), table_name="sensor_readings")
+    op.drop_table("sensor_readings")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi>=0.115.0
+uvicorn>=0.30.0
+sqlalchemy>=2.0.0
+psycopg2-binary>=2.9.0
+alembic>=1.13.0
+pytest>=8.0.0
+httpx>=0.27.0

--- a/tests/test_sensor_readings.py
+++ b/tests/test_sensor_readings.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base
+from app.main import app, get_db
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def make_payload(read_at: datetime | None = None):
+    return {
+        "farm_id": "farm-1",
+        "station_id": "station-7",
+        "crop": "soy",
+        "air_temperature": 29.5,
+        "air_humidity": 63.2,
+        "soil_temperature": 24.0,
+        "soil_humidity": 48.5,
+        "ph": 6.4,
+        "nitrogen": 11.2,
+        "phosphorus": 4.5,
+        "potassium": 7.9,
+        "battery_level": 76.8,
+        "read_at": (read_at or datetime.now(timezone.utc)).isoformat(),
+    }
+
+
+def test_create_sensor_reading(client):
+    response = client.post("/sensor-readings", json=make_payload())
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["id"] > 0
+    assert data["farm_id"] == "farm-1"
+
+
+def test_create_sensor_reading_validation_error(client):
+    payload = make_payload()
+    payload["air_humidity"] = 120
+
+    response = client.post("/sensor-readings", json=payload)
+
+    assert response.status_code == 422
+
+
+def test_get_latest_sensor_reading(client):
+    older = datetime.now(timezone.utc) - timedelta(hours=1)
+    newer = datetime.now(timezone.utc)
+
+    client.post("/sensor-readings", json=make_payload(read_at=older))
+    client.post("/sensor-readings", json=make_payload(read_at=newer))
+
+    response = client.get("/sensor-readings/latest")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["read_at"] == newer.isoformat()
+
+
+def test_get_latest_sensor_reading_not_found(client):
+    response = client.get("/sensor-readings/latest")
+
+    assert response.status_code == 404


### PR DESCRIPTION
### Motivation
- Fornecer uma API REST para receber e persistir leituras de sensores agrícolas da Fildee com validação e consulta da última leitura.

### Description
- Adiciona a camada de banco com `app/database.py` usando SQLAlchemy e `DATABASE_URL` configurável.
- Implementa o model `SensorReading` em `app/models.py` com os campos requisitados e índices principais.
- Cria schemas Pydantic em `app/schemas.py` com validações de faixa para temperatura/umidade/pH/bateria, não-negatividade para nutrientes e validação de `read_at` com tolerância de 5 minutos ao futuro.
- Expõe os endpoints `POST /sensor-readings` (criação) e `GET /sensor-readings/latest` (consulta da leitura mais recente) em `app/main.py` e adiciona a migration Alembic em `migrations/versions/20260425_0001_create_sensor_readings.py`.
- Inclui testes básicos em `tests/test_sensor_readings.py` e um `requirements.txt` com dependências do stack.

### Testing
- Adicionei testes que cobrem criação de leitura, validação de payload inválido, retorno da leitura mais recente e cenário sem leituras, todos definidos em `tests/test_sensor_readings.py`.
- Rodei `pytest -q` no ambiente de CI local configurado, que falhou durante a coleta com `ModuleNotFoundError: No module named 'fastapi'` devido a dependências não instaladas neste ambiente.
- A suite de testes está pronta para rodar e deve passar quando as dependências do `requirements.txt` estiverem instaladas e o ambiente de testes configurado corretamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece5333ccc832aae3c18aaea2f8f4e)