### PR TITLE
Adicionar endpoint GET /daily-report/{station_id} para consolidação de leituras 24h

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,30 @@ I'm the GitHub Learning Lab bot and I'm here to help guide you in your journey t
 I'll meet you over there, can't wait to get started!
 
 This course is using the :sparkles: open source project [reveal.js](https://github.com/hakimel/reveal.js/). In some cases we’ve made changes to the history so it would behave during class, so head to the original project repo to learn more about the cool people behind this project.
+
+## API de relatório diário
+
+Foi adicionado um endpoint HTTP para consolidar as leituras das últimas 24h por estação.
+
+### Executar
+
+```bash
+node api/server.js
+```
+
+### Endpoint
+
+`GET /daily-report/{station_id}`
+
+Exemplo:
+
+```bash
+curl http://localhost:3000/daily-report/station-1
+```
+
+Resposta:
+- `readings_count`: quantidade de leituras
+- `indicators`: média, mínima e máxima por indicador
+- `last_reading`: última leitura registrada
+- `overall_status`: `normal`, `atenção` ou `crítico`
+- `indicators_out_of_range`: lista de indicadores fora da faixa normal na última leitura

--- a/api/daily-report.js
+++ b/api/daily-report.js
@@ -1,0 +1,116 @@
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+function parseTimestamp(value) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function inNormalRange(value, range) {
+  if (!range) return true;
+  if (typeof range.min === 'number' && value < range.min) return false;
+  if (typeof range.max === 'number' && value > range.max) return false;
+  return true;
+}
+
+function inCriticalRange(value, range) {
+  if (!range) return true;
+  if (typeof range.min === 'number' && value < range.min) return false;
+  if (typeof range.max === 'number' && value > range.max) return false;
+  return true;
+}
+
+function summarizeByIndicator(readings) {
+  const accumulator = {};
+
+  readings.forEach((reading) => {
+    Object.entries(reading.indicators || {}).forEach(([indicator, value]) => {
+      if (typeof value !== 'number') return;
+
+      if (!accumulator[indicator]) {
+        accumulator[indicator] = {
+          sum: 0,
+          count: 0,
+          min: value,
+          max: value,
+        };
+      }
+
+      const current = accumulator[indicator];
+      current.sum += value;
+      current.count += 1;
+      current.min = Math.min(current.min, value);
+      current.max = Math.max(current.max, value);
+    });
+  });
+
+  const summary = {};
+  Object.entries(accumulator).forEach(([indicator, stats]) => {
+    summary[indicator] = {
+      average: Number((stats.sum / stats.count).toFixed(2)),
+      min: stats.min,
+      max: stats.max,
+    };
+  });
+
+  return summary;
+}
+
+function getOverallStatus(lastReading, indicatorRanges) {
+  const outsideRange = [];
+  let critical = false;
+
+  Object.entries(lastReading.indicators || {}).forEach(([indicator, value]) => {
+    if (typeof value !== 'number') return;
+
+    const range = indicatorRanges[indicator] || {};
+    const normalRange = range.normal;
+    const criticalRange = range.critical;
+
+    if (!inNormalRange(value, normalRange)) {
+      outsideRange.push(indicator);
+    }
+
+    if (!inCriticalRange(value, criticalRange)) {
+      critical = true;
+    }
+  });
+
+  if (critical) return { status: 'crítico', outsideRange };
+  if (outsideRange.length > 0) return { status: 'atenção', outsideRange };
+  return { status: 'normal', outsideRange };
+}
+
+function buildDailyReport(station, now = new Date()) {
+  const stationReadings = station.readings || [];
+  const nowDate = now instanceof Date ? now : new Date(now);
+  const lowerBound = nowDate.getTime() - DAY_IN_MS;
+
+  const readingsInWindow = stationReadings
+    .map((reading) => ({ ...reading, parsedTimestamp: parseTimestamp(reading.timestamp) }))
+    .filter((reading) => reading.parsedTimestamp && reading.parsedTimestamp.getTime() >= lowerBound)
+    .sort((a, b) => a.parsedTimestamp.getTime() - b.parsedTimestamp.getTime());
+
+  if (readingsInWindow.length === 0) {
+    return null;
+  }
+
+  const lastReading = readingsInWindow[readingsInWindow.length - 1];
+  const indicatorRanges = station.indicatorRanges || {};
+  const { status, outsideRange } = getOverallStatus(lastReading, indicatorRanges);
+
+  return {
+    station_id: station.station_id,
+    readings_count: readingsInWindow.length,
+    indicators: summarizeByIndicator(readingsInWindow),
+    last_reading: {
+      timestamp: lastReading.timestamp,
+      indicators: lastReading.indicators,
+    },
+    overall_status: status,
+    indicators_out_of_range: outsideRange,
+  };
+}
+
+module.exports = {
+  buildDailyReport,
+};

--- a/api/daily-report.test.js
+++ b/api/daily-report.test.js
@@ -1,0 +1,50 @@
+const assert = require('assert');
+const { buildDailyReport } = require('./daily-report');
+
+const station = {
+  station_id: 'station-1',
+  indicatorRanges: {
+    temperature: {
+      normal: { min: 10, max: 35 },
+      critical: { min: 5, max: 40 },
+    },
+    humidity: {
+      normal: { min: 30, max: 75 },
+      critical: { min: 20, max: 85 },
+    },
+  },
+  readings: [
+    {
+      timestamp: '2026-04-24T16:00:00Z',
+      indicators: { temperature: 20, humidity: 60 },
+    },
+    {
+      timestamp: '2026-04-25T12:00:00Z',
+      indicators: { temperature: 38, humidity: 80 },
+    },
+  ],
+};
+
+const report = buildDailyReport(station, new Date('2026-04-25T16:00:00Z'));
+assert(report, 'Report should not be null');
+assert.strictEqual(report.readings_count, 2);
+assert.strictEqual(report.indicators.temperature.average, 29);
+assert.strictEqual(report.last_reading.indicators.temperature, 38);
+assert.strictEqual(report.overall_status, 'atenção');
+assert.deepStrictEqual(report.indicators_out_of_range.sort(), ['humidity', 'temperature']);
+
+const emptyReport = buildDailyReport(
+  {
+    station_id: 'station-2',
+    readings: [
+      {
+        timestamp: '2026-04-20T00:00:00Z',
+        indicators: { temperature: 18 },
+      },
+    ],
+  },
+  new Date('2026-04-25T16:00:00Z')
+);
+assert.strictEqual(emptyReport, null);
+
+console.log('daily-report tests passed');

--- a/api/data/readings.json
+++ b/api/data/readings.json
@@ -1,0 +1,45 @@
+[
+  {
+    "station_id": "station-1",
+    "indicatorRanges": {
+      "temperature": {
+        "normal": { "min": 10, "max": 35 },
+        "critical": { "min": 5, "max": 40 }
+      },
+      "humidity": {
+        "normal": { "min": 30, "max": 75 },
+        "critical": { "min": 20, "max": 85 }
+      },
+      "ph": {
+        "normal": { "min": 6.5, "max": 8.5 },
+        "critical": { "min": 6, "max": 9 }
+      }
+    },
+    "readings": [
+      {
+        "timestamp": "2026-04-24T18:00:00Z",
+        "indicators": {
+          "temperature": 28,
+          "humidity": 54,
+          "ph": 7.2
+        }
+      },
+      {
+        "timestamp": "2026-04-25T08:30:00Z",
+        "indicators": {
+          "temperature": 31,
+          "humidity": 72,
+          "ph": 8.2
+        }
+      },
+      {
+        "timestamp": "2026-04-25T15:15:00Z",
+        "indicators": {
+          "temperature": 37,
+          "humidity": 81,
+          "ph": 8.7
+        }
+      }
+    ]
+  }
+]

--- a/api/server.js
+++ b/api/server.js
@@ -1,0 +1,59 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { buildDailyReport } = require('./daily-report');
+
+const DATA_PATH = path.join(__dirname, 'data', 'readings.json');
+const PORT = process.env.PORT || 3000;
+
+function loadStations() {
+  const raw = fs.readFileSync(DATA_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(payload, null, 2));
+}
+
+function handleRequest(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (req.method !== 'GET') {
+    return sendJson(res, 405, { error: 'Method Not Allowed' });
+  }
+
+  const match = url.pathname.match(/^\/daily-report\/([^/]+)$/);
+  if (!match) {
+    return sendJson(res, 404, { error: 'Not Found' });
+  }
+
+  const stationId = decodeURIComponent(match[1]);
+  const stations = loadStations();
+  const station = stations.find((item) => item.station_id === stationId);
+
+  if (!station) {
+    return sendJson(res, 404, { error: `Station '${stationId}' not found` });
+  }
+
+  const report = buildDailyReport(station);
+  if (!report) {
+    return sendJson(res, 404, { error: 'No readings in the last 24h' });
+  }
+
+  return sendJson(res, 200, report);
+}
+
+const server = http.createServer(handleRequest);
+
+if (require.main === module) {
+  server.listen(PORT, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Server running on http://localhost:${PORT}`);
+  });
+}
+
+module.exports = {
+  server,
+  handleRequest,
+};


### PR DESCRIPTION
### Motivation
- Fornecer um relatório por estação agregando leituras das últimas 24h para facilitar monitoramento operacional. 
- Incluir estatísticas por indicador (média, mínimo, máximo), a última leitura registrada e um status geral baseado em faixas `normal`/`critical`.
- Retornar respostas apropriadas quando a estação não existir ou não houver leituras na janela de 24h.

### Description
- Adiciona a lógica de consolidação em `api/daily-report.js`, que filtra leituras nas últimas 24h, calcula média/min/max por indicador e determina status (`normal`, `atenção`, `crítico`) a partir das faixas `normal` e `critical` configuradas por indicador.
- Implementa um servidor HTTP simples em `api/server.js` que expõe `GET /daily-report/{station_id}` e retorna JSON com `readings_count`, `indicators`, `last_reading`, `overall_status` e `indicators_out_of_range` ou erros `404`/`405` conforme o caso.
- Inclui dados de exemplo em `api/data/readings.json`, adiciona testes em `api/daily-report.test.js` para a função `buildDailyReport` e documenta o endpoint no `README.md`.
- A determinação de status prioriza `crítico` (se qualquer indicador estiver fora da faixa crítica), em seguida `atenção` (fora da faixa normal) e `normal` caso contrário.

### Testing
- Executado o teste automatizado `node api/daily-report.test.js`, que passou com sucesso (`daily-report tests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ece893d5b0832ab76fff08bb2f1e07)