### PR TITLE
feat: adicionar dashboard Fildee responsivo em React + TypeScript

### DIFF
--- a/fildee-dashboard/index.html
+++ b/fildee-dashboard/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fildee Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/fildee-dashboard/package.json
+++ b/fildee-dashboard/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "fildee-dashboard",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.9",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.10"
+  }
+}

--- a/fildee-dashboard/src/Dashboard.css
+++ b/fildee-dashboard/src/Dashboard.css
@@ -1,0 +1,207 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  background: #eef3f6;
+  color: #1d2939;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+.dashboard {
+  min-height: 100vh;
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.dashboard__hero,
+.dashboard__card,
+.dashboard__panel {
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.dashboard__hero {
+  padding: 1.5rem;
+}
+
+.dashboard__overline {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #0f766e;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.dashboard h1 {
+  margin: 0.4rem 0 0.6rem;
+}
+
+.dashboard__subtitle {
+  margin: 0;
+  color: #475467;
+}
+
+.dashboard__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.8rem;
+}
+
+.dashboard__card {
+  padding: 1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.dashboard__card p {
+  margin: 0;
+  color: #667085;
+  font-size: 0.9rem;
+}
+
+.dashboard__card strong {
+  font-size: 1.6rem;
+}
+
+.dashboard__trend {
+  color: #475467;
+  font-size: 0.85rem;
+}
+
+.dashboard__trend--up {
+  color: #047857;
+}
+
+.dashboard__trend--down {
+  color: #b42318;
+}
+
+.dashboard__grid {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+}
+
+.dashboard__panel {
+  padding: 1rem;
+  grid-column: span 12;
+}
+
+.dashboard__panelHeader h3 {
+  margin: 0 0 1rem;
+  font-size: 1.05rem;
+}
+
+.chart {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.chart svg {
+  width: 100%;
+  height: auto;
+  background: linear-gradient(180deg, #f8fafc 0%, #eff4f8 100%);
+  border-radius: 12px;
+  padding: 0.35rem;
+}
+
+.chart__labels {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.35rem;
+}
+
+.chart__labels li {
+  display: grid;
+  gap: 0.2rem;
+  text-align: center;
+  font-size: 0.8rem;
+  color: #475467;
+}
+
+.chart__labels strong {
+  color: #1d2939;
+}
+
+.dashboard__panel--insight {
+  background: linear-gradient(140deg, #115e59, #0f766e);
+  color: #f5fffc;
+}
+
+.dashboard__panel--insight p {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.dashboard__panel--insight ul {
+  margin: 0.9rem 0 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.alerts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.alert {
+  display: grid;
+  grid-template-columns: 60px 1fr;
+  gap: 0.7rem;
+  padding: 0.65rem;
+  border-radius: 10px;
+  background: #f8fafc;
+  border-left: 4px solid #98a2b3;
+}
+
+.alert p {
+  margin: 0;
+}
+
+.alert span {
+  font-weight: 700;
+}
+
+.alert--high {
+  border-left-color: #b42318;
+}
+
+.alert--medium {
+  border-left-color: #eb7f35;
+}
+
+.alert--low {
+  border-left-color: #1570ef;
+}
+
+@media (min-width: 900px) {
+  .dashboard {
+    padding: 2rem;
+  }
+
+  .dashboard__panel:nth-child(1),
+  .dashboard__panel:nth-child(2) {
+    grid-column: span 6;
+  }
+
+  .dashboard__panel--insight,
+  .dashboard__panel:last-child {
+    grid-column: span 6;
+  }
+}

--- a/fildee-dashboard/src/Dashboard.tsx
+++ b/fildee-dashboard/src/Dashboard.tsx
@@ -1,0 +1,167 @@
+type Indicator = {
+  label: string;
+  value: string;
+  variation: string;
+  trend: 'up' | 'down' | 'neutral';
+};
+
+type DataPoint = {
+  label: string;
+  value: number;
+};
+
+type Alert = {
+  time: string;
+  title: string;
+  level: 'alta' | 'média' | 'baixa';
+};
+
+const indicators: Indicator[] = [
+  { label: 'Umidade média do solo', value: '41%', variation: '+3% vs. ontem', trend: 'up' },
+  { label: 'Temperatura do ar', value: '28°C', variation: '+1.2°C hoje', trend: 'up' },
+  { label: 'Talhões monitorados', value: '24', variation: '100% online', trend: 'neutral' },
+  { label: 'Risco hídrico', value: 'Baixo', variation: '-12% na semana', trend: 'down' }
+];
+
+const soilMoistureSeries: DataPoint[] = [
+  { label: 'Seg', value: 35 },
+  { label: 'Ter', value: 37 },
+  { label: 'Qua', value: 39 },
+  { label: 'Qui', value: 44 },
+  { label: 'Sex', value: 42 },
+  { label: 'Sáb', value: 41 },
+  { label: 'Dom', value: 43 }
+];
+
+const airTemperatureSeries: DataPoint[] = [
+  { label: 'Seg', value: 24 },
+  { label: 'Ter', value: 26 },
+  { label: 'Qua', value: 27 },
+  { label: 'Qui', value: 30 },
+  { label: 'Sex', value: 29 },
+  { label: 'Sáb', value: 28 },
+  { label: 'Dom', value: 27 }
+];
+
+const recentAlerts: Alert[] = [
+  { time: '08:15', title: 'Queda brusca de umidade no Talhão 07', level: 'alta' },
+  { time: '10:40', title: 'Pico de temperatura acima de 31°C', level: 'média' },
+  { time: '13:05', title: 'Sensor S-14 precisa de calibração', level: 'baixa' },
+  { time: '16:20', title: 'Janela ideal de irrigação iniciada', level: 'média' }
+];
+
+const trendLabel: Record<Indicator['trend'], string> = {
+  up: 'dashboard__trend dashboard__trend--up',
+  down: 'dashboard__trend dashboard__trend--down',
+  neutral: 'dashboard__trend'
+};
+
+const alertLabel: Record<Alert['level'], string> = {
+  alta: 'alert alert--high',
+  média: 'alert alert--medium',
+  baixa: 'alert alert--low'
+};
+
+function LineChart({ title, data, color, unit }: { title: string; data: DataPoint[]; color: string; unit: string }) {
+  const width = 720;
+  const height = 230;
+  const min = Math.min(...data.map((d) => d.value)) - 2;
+  const max = Math.max(...data.map((d) => d.value)) + 2;
+
+  const points = data
+    .map((point, index) => {
+      const x = (index / (data.length - 1)) * (width - 40) + 20;
+      const y = height - ((point.value - min) / (max - min)) * (height - 40) - 20;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <article className="dashboard__panel">
+      <header className="dashboard__panelHeader">
+        <h3>{title}</h3>
+      </header>
+
+      <div className="chart">
+        <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label={title}>
+          <polyline points={points} stroke={color} strokeWidth="4" fill="none" strokeLinecap="round" />
+          {data.map((point, index) => {
+            const x = (index / (data.length - 1)) * (width - 40) + 20;
+            const y = height - ((point.value - min) / (max - min)) * (height - 40) - 20;
+            return <circle key={point.label} cx={x} cy={y} r="4" fill={color} />;
+          })}
+        </svg>
+
+        <ul className="chart__labels">
+          {data.map((point) => (
+            <li key={point.label}>
+              <span>{point.label}</span>
+              <strong>
+                {point.value}
+                {unit}
+              </strong>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </article>
+  );
+}
+
+export function Dashboard() {
+  return (
+    <main className="dashboard">
+      <section className="dashboard__hero">
+        <div>
+          <p className="dashboard__overline">Fildee · Monitoramento inteligente</p>
+          <h1>Painel operacional de campo</h1>
+          <p className="dashboard__subtitle">Visão consolidada dos indicadores climáticos e recomendações automáticas para tomada de decisão.</p>
+        </div>
+      </section>
+
+      <section className="dashboard__cards" aria-label="Indicadores atuais">
+        {indicators.map((indicator) => (
+          <article key={indicator.label} className="dashboard__card">
+            <p>{indicator.label}</p>
+            <strong>{indicator.value}</strong>
+            <span className={trendLabel[indicator.trend]}>{indicator.variation}</span>
+          </article>
+        ))}
+      </section>
+
+      <section className="dashboard__grid">
+        <LineChart title="Evolução da umidade do solo" data={soilMoistureSeries} color="#1fa87a" unit="%" />
+        <LineChart title="Temperatura do ar" data={airTemperatureSeries} color="#eb7f35" unit="°C" />
+
+        <article className="dashboard__panel dashboard__panel--insight">
+          <header className="dashboard__panelHeader">
+            <h3>Insight da IA Fildee</h3>
+          </header>
+          <p>
+            Com base no padrão dos últimos 7 dias, a IA prevê redução de 6% na umidade média entre domingo e segunda-feira.
+            Recomendação: antecipar irrigação noturna no Talhão 07 e priorizar áreas com temperatura acima de 29°C.
+          </p>
+          <ul>
+            <li>Probabilidade de estresse hídrico em 48h: <strong>72%</strong></li>
+            <li>Janela sugerida de irrigação: <strong>22:00 às 01:30</strong></li>
+            <li>Economia estimada de água com ajuste fino: <strong>até 14%</strong></li>
+          </ul>
+        </article>
+
+        <article className="dashboard__panel">
+          <header className="dashboard__panelHeader">
+            <h3>Alertas recentes</h3>
+          </header>
+          <ul className="alerts">
+            {recentAlerts.map((alert) => (
+              <li key={`${alert.time}-${alert.title}`} className={alertLabel[alert.level]}>
+                <span>{alert.time}</span>
+                <p>{alert.title}</p>
+              </li>
+            ))}
+          </ul>
+        </article>
+      </section>
+    </main>
+  );
+}

--- a/fildee-dashboard/src/main.tsx
+++ b/fildee-dashboard/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Dashboard } from './Dashboard';
+import './Dashboard.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Dashboard />
+  </React.StrictMode>
+);

--- a/fildee-dashboard/tsconfig.json
+++ b/fildee-dashboard/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/fildee-dashboard/vite.config.ts
+++ b/fildee-dashboard/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
### Motivation
- Fornecer uma tela operacional para a Fildee com visão consolidada de indicadores e recomendações automáticas para tomada de decisão em campo.
- Incluir visualizações essenciais solicitadas: cards de indicadores, gráfico de umidade do solo, gráfico de temperatura do ar, área de insight de IA e lista de alertas.
- Entregar uma implementação pronta para desenvolvimento local usando Vite e TypeScript com layout responsivo para desktop e mobile.

### Description
- Adicionado scaffold da app em `fildee-dashboard/` com `package.json`, `tsconfig.json`, e `vite.config.ts` para rodar via Vite.
- Implementado o componente principal em `src/Dashboard.tsx` com indicadores, séries de dados mock, componentes de gráfico SVG (`LineChart`), seção de "Insight da IA Fildee" e lista de `recentAlerts`.
- Conectado o ponto de entrada em `src/main.tsx` e adicionada a página `index.html` para o build/preview local.
- Estilização responsiva e regras de layout em `src/Dashboard.css` incluindo grid adaptativo, cards e destaque visual para alertas e insight.

### Testing
- Executado `npm install` dentro de `fildee-dashboard/` como validação automatizada de instalação de dependências, que falhou com `403 Forbidden` do registry e impediu instalação de pacotes.
- Devido ao erro de acesso ao registry não foi possível executar `vite`/build automatizado nem testes de render em navegador neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecea6a9e34832aa290823d23ead195)